### PR TITLE
Fix is_extended to be comptime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cockroach-data
-zig-cache
+zig-cache/
+zig-out/

--- a/src/sql_builder.zig
+++ b/src/sql_builder.zig
@@ -90,7 +90,7 @@ pub const Builder = struct {
         _ = try self.values.append(self.buffer.toOwnedSlice());
     }
 
-    pub fn autoAdd(self: *Builder, struct_info: anytype, comptime field_info: FieldInfo, field_value: anytype, extended: bool) !void {
+    pub fn autoAdd(self: *Builder, struct_info: anytype, comptime field_info: FieldInfo, field_value: anytype, comptime extended: bool) !void {
         if (@typeInfo(field_info.type) == .Optional and field_value == null) return;
         switch (field_info.type) {
             i16, i32, u8, u16, u32, usize => {

--- a/tests/database.zig
+++ b/tests/database.zig
@@ -190,12 +190,12 @@ test "Nullable type" {
     });
 
     var result = try db.execValues("SELECT * FROM keyValue WHERE value = {d}", .{42});
-    var value42 = result5.parse(KeyValue, null).?;
+    var value42 = result.parse(KeyValue, null).?;
     testing.expect(value42.id != null);
     testing.expectEqual(value42.value, 42);
 
-    var result = try db.execValues("SELECT * FROM keyValue WHERE value = {d}", .{33});
-    var value33 = result5.parse(KeyValue, null).?;
+    var result2 = try db.execValues("SELECT * FROM keyValue WHERE value = {d}", .{33});
+    var value33 = result2.parse(KeyValue, null).?;
     testing.expect(value33.id != null);
     testing.expect(value33.id > value42.id);
 

--- a/tests/database.zig
+++ b/tests/database.zig
@@ -162,3 +162,42 @@ test "Custom types" {
 
     _ = try db.exec("DROP TABLE player");
 }
+
+const KeyValue = struct {
+    id: ?u32 = null,
+    value: i32,
+};
+
+test "Nullable type" {
+    var db = try Pg.connect(allocator, build_options.db_uri);
+
+    defer {
+        std.debug.assert(!gpa.deinit());
+        db.deinit();
+    }
+
+    const schema =
+        \\CREATE DATABASE IF NOT EXISTS root;
+        \\CREATE TABLE IF NOT EXISTS keyValue (id SERIAL PRIMARY KEY, value int);
+    ;
+
+    _ = try db.exec(schema);
+
+    _ = try db.insert(&[_]KeyValue{
+        KeyValue{ .value = 42 },
+        KeyValue{ .value = 741 },
+        KeyValue{ .value = 33 },
+    });
+
+    var result = try db.execValues("SELECT * FROM keyValue WHERE value = {d}", .{42});
+    var value42 = result5.parse(KeyValue, null).?;
+    testing.expect(value42.id != null);
+    testing.expectEqual(value42.value, 42);
+
+    var result = try db.execValues("SELECT * FROM keyValue WHERE value = {d}", .{33});
+    var value33 = result5.parse(KeyValue, null).?;
+    testing.expect(value33.id != null);
+    testing.expect(value33.id > value42.id);
+
+    _ = try db.exec("DROP TABLE keyValue");
+}


### PR DESCRIPTION
Changes the parameter is_extended of autoAdd to be comptime so it will register optional values correctly.